### PR TITLE
fix: vite-plugin-svelte-css-no-scopable-elements

### DIFF
--- a/src/lib/crop_window/CropMediaView.svelte
+++ b/src/lib/crop_window/CropMediaView.svelte
@@ -512,14 +512,3 @@
     {/if}
     -->
 {/if}
-
-<style>
-    /*
-    .p {
-        background-color: red;
-        width: 5px;
-        height: 5px;
-        box-sizing: border-box;
-    }
-    */
-</style>


### PR DESCRIPTION
`CropMediaView.svelte` has a style tag with all the styles commented out and that results in this warning in the console:

```sh
[vite-plugin-svelte] .../node_modules/svelte-crop-window/crop_window/CropMediaView.svelte:341:1
No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS.
See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.
```

This PR just removes the empty style tag so users don't have to silence the warning in `svelte.config.js` `config.onWarn`